### PR TITLE
Fix path getting for document reference

### DIFF
--- a/lib/src/document_ref.dart
+++ b/lib/src/document_ref.dart
@@ -26,7 +26,8 @@ class DocumentRef implements DocumentRefImpl {
 
   /// A string representing the path of the referenced document (relative to the
   /// root of the database).
-  String get path => '${_delegate?.path ?? ''}$id';
+  String get path => '${_delegate?.path}$id';
+
   final _utils = Utils.instance;
 
   final Map<String, dynamic> _data = {};

--- a/lib/src/utils/io.dart
+++ b/lib/src/utils/io.dart
@@ -174,7 +174,7 @@ class Utils implements UtilsImpl {
       _docDir = dir;
       return dir;
     } catch (error) {
-      throw error;
+      rethrow;
     }
   }
 
@@ -188,6 +188,7 @@ class Utils implements UtilsImpl {
     _file.setPositionSync(0);
     _file.writeFromSync(buffer);
     _file.truncateSync(buffer.length);
+    _file.unlockSync();
     _file.closeSync();
 
     final _key = path.replaceAll(RegExp(r'[^\/]+\/?$'), '');


### PR DESCRIPTION
PR should fix the problem with document delition through fixing how path getter works

There's some other changes in I made to library, but I think this one-liner is the only relevant one. Please check if that's correct before merging

https://github.com/chuyentt/localstore/issues/7