### PR TITLE
Fixed issue where `delete` call was not awaited leading to a possible inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## [1.3.6] - 2023-04-03
+
+* Fixed issue where `delete` call was not awaited leading to a possible inconsistency when 
+  deleting and then reading a ref immediately afterwards
 
 ## [1.3.5] - 2023-02-26
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -113,7 +113,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.4"
+    version: "1.3.5"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/utils/io.dart
+++ b/lib/src/utils/io.dart
@@ -71,9 +71,9 @@ class Utils implements UtilsImpl {
   @override
   Future delete(String path) async {
     if (path.endsWith(Platform.pathSeparator)) {
-      _deleteDirectory(path);
+      await _deleteDirectory(path);
     } else {
-      _deleteFile(path);
+      await _deleteFile(path);
     }
   }
 
@@ -195,8 +195,8 @@ class Utils implements UtilsImpl {
     final fullPath = docDir.path;
     final file = File('$fullPath$path');
 
-    if (file.existsSync()) {
-      file.deleteSync();
+    if (await file.exists()) {
+      await file.delete();
       _fileCache.remove(path);
     }
   }
@@ -206,8 +206,8 @@ class Utils implements UtilsImpl {
     final fullPath = docDir.path;
     final dir = Directory('$fullPath$path');
 
-    if (dir.existsSync()) {
-      dir.deleteSync(recursive: true);
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
       _fileCache.removeWhere((key, value) => key.startsWith(path));
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: localstore
 description: A JSON file-based storage package provides a persistent repository for simple NoSQL database.
 
-version: 1.3.5
+version: 1.3.6
 homepage: https://github.com/chuyentt/localstore
 
 environment:


### PR DESCRIPTION
Hi, similar to previous pull request, this addresses a condition where if you delete a ref and then immediately read it again the 'deleted' document still shows up. This is caused by not 'awaiting' the calls to `_deleteDirectory` and `_deleteFile`, so I added that. Also changed some of the 'existsSync' etc call to just await (not entirely sure but I believe it's better to not use the 'sync' calls and there is no need for it given you're already in an async function.