### PR TITLE
Option to set databaseDirectory (defaults to  getApplicationDocuments…

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -113,7 +113,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.4"
+    version: "1.3.5"
   matcher:
     dependency: transitive
     description:

--- a/lib/localstore.dart
+++ b/lib/localstore.dart
@@ -6,7 +6,11 @@
 /// Localstore library
 library localstore;
 
+import 'dart:async';
+import 'dart:io';
+
 import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'dart:math';
 
 import 'src/utils/html.dart' if (dart.library.io) 'src/utils/io.dart';

--- a/lib/src/localstore_base.dart
+++ b/lib/src/localstore_base.dart
@@ -8,9 +8,20 @@ part of localstore;
 /// final db = Localstore.instance;
 /// ```
 class Localstore implements LocalstoreImpl {
+  var _databaseDirectoryCompleter = Completer<Directory>();
   final _delegate = DocumentRef._('');
-  Localstore._();
   static final Localstore _localstore = Localstore._();
+
+  /// Private initializer
+  ///
+  /// Sets the [_databaseDirectoryCompleter] if not already set through user override
+  Localstore._() {
+    getApplicationDocumentsDirectory().then((dir) {
+      if (!_databaseDirectoryCompleter.isCompleted) {
+        _databaseDirectoryCompleter.complete(dir);
+      }
+    });
+  }
 
   /// Returns an instance using the default [Localstore].
   static Localstore get instance => _localstore;
@@ -18,5 +29,18 @@ class Localstore implements LocalstoreImpl {
   @override
   CollectionRef collection(String path) {
     return CollectionRef(path, null, _delegate);
+  }
+
+  @override
+  Future<Directory> getDatabaseDirectory() => _databaseDirectoryCompleter.future;
+
+  @override
+  void setDatabaseDirectory(Directory dir) {
+    // complete, or replace the completer if already completed
+    final completer = _databaseDirectoryCompleter.isCompleted
+        ? Completer<Directory>()
+        : _databaseDirectoryCompleter;
+    _databaseDirectoryCompleter = completer;
+    completer.complete(dir);
   }
 }

--- a/lib/src/localstore_impl.dart
+++ b/lib/src/localstore_impl.dart
@@ -4,4 +4,10 @@ part of localstore;
 abstract class LocalstoreImpl {
   /// Gets a [CollectionRef] for the specified Localstore path.
   CollectionRef collection(String path);
+
+  /// Get the directory where the database is stored
+  Future<Directory> getDatabaseDirectory();
+
+  /// Set the directory where the database is stored
+  void setDatabaseDirectory(Directory dir);
 }

--- a/lib/src/utils/io.dart
+++ b/lib/src/utils/io.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:path_provider/path_provider.dart';
+import 'package:localstore/localstore.dart';
 
 import 'utils_impl.dart';
 
@@ -20,8 +20,8 @@ class Utils implements UtilsImpl {
       [bool? isCollection = false, List<List>? conditions]) async {
     // Fetch the documents for this collection
     if (isCollection != null && isCollection == true) {
-      final docDir = await getApplicationDocumentsDirectory();
-      final fullPath = '${docDir.path}$path';
+      final dbDir = await Localstore.instance.getDatabaseDirectory();
+      final fullPath = '${dbDir.path}$path';
       final dir = Directory(fullPath);
       if (!dir.existsSync()) {
         dir.createSync(recursive: true);
@@ -91,9 +91,9 @@ class Utils implements UtilsImpl {
 
   Future<Map<String, dynamic>?> _getAll(List<FileSystemEntity> entries) async {
     final items = <String, dynamic>{};
-    final docDir = await getApplicationDocumentsDirectory();
+    final dbDir = await Localstore.instance.getDatabaseDirectory();
     await Future.forEach(entries, (FileSystemEntity e) async {
-      final path = e.path.replaceAll(docDir.absolute.path, '');
+      final path = e.path.replaceAll(dbDir.path, '');
       final file = await _getFile(path);
       final randomAccessFile = await file!.open(mode: FileMode.append);
       final data = await _readFile(randomAccessFile);
@@ -120,14 +120,14 @@ class Utils implements UtilsImpl {
     StreamController<Map<String, dynamic>> storage,
     String path,
   ) async {
-    final docDir = await getApplicationDocumentsDirectory();
-    final fullPath = '${docDir.path}$path';
+    final dbDir = await Localstore.instance.getDatabaseDirectory();
+    final fullPath = '${dbDir.path}$path';
     final dir = Directory(fullPath);
     try {
       List<FileSystemEntity> entries =
           dir.listSync(recursive: false).whereType<File>().toList();
       for (var e in entries) {
-        final path = e.path.replaceAll(docDir.absolute.path, '');
+        final path = e.path.replaceAll(dbDir.path, '');
         final file = await _getFile(path);
         final randomAccessFile = file!.openSync(mode: FileMode.append);
         _readFile(randomAccessFile).then((data) {
@@ -159,11 +159,9 @@ class Utils implements UtilsImpl {
   Future<File?> _getFile(String path) async {
     if (_fileCache.containsKey(path)) return _fileCache[path];
 
-    final docDir = await getApplicationDocumentsDirectory();
+    final dbDir = await Localstore.instance.getDatabaseDirectory();
 
-    final fullPath = docDir.path;
-
-    final file = File('$fullPath$path');
+    final file = File('${dbDir.path}$path');
 
     if (!file.existsSync()) file.createSync(recursive: true);
     _fileCache.putIfAbsent(path, () => file);
@@ -191,9 +189,8 @@ class Utils implements UtilsImpl {
   }
 
   Future _deleteFile(String path) async {
-    final docDir = await getApplicationDocumentsDirectory();
-    final fullPath = docDir.path;
-    final file = File('$fullPath$path');
+    final dbDir = await Localstore.instance.getDatabaseDirectory();
+    final file = File('${dbDir.path}$path');
 
     if (file.existsSync()) {
       file.deleteSync();
@@ -202,9 +199,8 @@ class Utils implements UtilsImpl {
   }
 
   Future _deleteDirectory(String path) async {
-    final docDir = await getApplicationDocumentsDirectory();
-    final fullPath = docDir.path;
-    final dir = Directory('$fullPath$path');
+    final dbDir = await Localstore.instance.getDatabaseDirectory();
+    final dir = Directory('${dbDir.path}$path');
 
     if (dir.existsSync()) {
       dir.deleteSync(recursive: true);


### PR DESCRIPTION
Fixes issue #19

The default directory used to store the database is that returned by `getApplicationDocumentsDirectory`. According to the documentation, that directory is meant to store _user generated_ files, as they are visible in - for instance - the 'Documents' folder on Linux, and can be made visible to the Files app on iOS. The better convention is to store the databases files in the directory returned by `getApplicationSupportDirectory`, as database files are not user generated.

This PR doesn't change anything in terms of storage directory, so is 100% backward compatible, but it does allow the developer to set the base directory for storing the database files by calling `setDatabaseDirectory` on the `Localstore` object. This should be done before any database interactions are required.

Please take a look and integrate if possible: I am dependent on this change for a change to the [background_downloader](https://pub.dev/packages/background_downloader) package and because you can't publish a package with git dependencies,  I can only move forward if this is published in your package. 

You may want to add a line about this in the README too - I did not modify that.