### PR TITLE
fix document_ref.set function for SetOption working

### DIFF
--- a/lib/src/document_ref.dart
+++ b/lib/src/document_ref.dart
@@ -37,9 +37,9 @@ class DocumentRef implements DocumentRefImpl {
     options ??= SetOptions();
     if (options.merge) {
       final output = Map<String, dynamic>.from(data);
-      Map<String, dynamic>? input = _data[id] ?? {};
+      Map<String, dynamic>? input = await get() ?? {};
       output.updateAll((key, value) {
-        input![key] = value;
+        input[key] = value;
       });
       _data[id] = input;
     } else {


### PR DESCRIPTION
Hi, I'm a mobile application developer using your localstore library!
This is a pull request for better functionality.

## Before this commit
``` dart
document_ref.set(
    {
        "data": "something",
    },
    SetOption(merge: true),
);
```
doesn't work.
Because `_data` doesn't have the document data.
So empty Map + {"data": "something"} just go into the existing doc. (In fact, this is `merge: false`)

## After this commit
SetOption works properly.

## Related Issue
Closes #10